### PR TITLE
Document resetProgress side effects

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1902,6 +1902,16 @@ class PronunciationQuest {
         console.log('Всі аудіо зупинено');
     }
 
+    /**
+     * Reset the entire game progress and return to the initial state.
+     *
+     * This method clears any saved data from localStorage and sets
+     * `blockProgressSaving` to `true`, preventing further automatic saving
+     * of progress. A confirmation dialog is shown to the user before the
+     * reset occurs.
+     *
+     * @returns {void}
+     */
     // Додаємо метод для скидання прогресу
     resetProgress() {
         // Запитуємо підтвердження перед скиданням


### PR DESCRIPTION
## Summary
- document resetProgress with a JSDoc block describing its behavior

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6842b18b64008324b153f8d190f2389c