### PR TITLE
Fix long vowel detection

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -899,7 +899,7 @@ class PronunciationQuest {
                 const transcription = this.currentWord.transcription;
                 let category = 0;
                 
-                if (transcription.includes('iː') || transcription.includes('ɑː') || transcription.includes('ɔː')) {
+                if (transcription.includes('iː') || transcription.includes('ɑː') || transcription.includes('ɔː') || transcription.includes('uː') || transcription.includes('ɜː')) {
                     category = 1;
                 } else if (transcription.includes('eɪ') || transcription.includes('aɪ') || transcription.includes('ɔɪ')) {
                     category = 2;


### PR DESCRIPTION
## Summary
- detect `/uː/` and `/ɜː/` in `getCorrectAnswer`

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6842b18a58d483248a75383041f5f909