### PR TITLE
Fix function name typo

### DIFF
--- a/assets/js/phonetics-zone.js
+++ b/assets/js/phonetics-zone.js
@@ -309,7 +309,7 @@ class PhoneticsZone {
         playButtons.forEach(btn => {
             btn.addEventListener('click', () => {
                 const text = btn.dataset.text;
-                this.playTonguetwister(text);
+                this.playTongueTwister(text);
             });
         });
 
@@ -395,7 +395,7 @@ class PhoneticsZone {
      * Відтворює скоромовку
      * @param {string} text - Текст скоромовки
      */
-    playTonguetwister(text) {
+    playTongueTwister(text) {
         this.synthesizeAndPlayWord(text);
     }
 


### PR DESCRIPTION
## Summary
- rename `playTonguetwister` to `playTongueTwister`
- update the call sites

## Testing
- `grep -R "playTonguetwister" -n . | wc -l`

------
https://chatgpt.com/codex/tasks/task_e_6842b187543c832494c1d63ab8ab7343