### PR TITLE
Add flashcards mode and expand vocabulary

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1404,6 +1404,54 @@ body {
     box-shadow: 0 6px 8px rgba(0, 0, 0, 0.15);
 }
 
+/* --- Flashcards --- */
+.flashcards-section {
+    background: rgba(255, 255, 255, 0.95);
+    border-radius: 20px;
+    padding: 40px;
+    margin-bottom: 30px;
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.2);
+    backdrop-filter: blur(10px);
+    animation: fade-in 0.5s ease-out;
+}
+
+.flashcard-container {
+    max-width: 600px;
+    margin: 0 auto;
+    text-align: center;
+}
+
+.flashcard-word {
+    font-size: 2.5em;
+    font-weight: bold;
+    margin-bottom: 15px;
+}
+
+.flashcard-info {
+    font-size: 1.5em;
+    margin-bottom: 20px;
+}
+
+.flashcard-controls {
+    display: flex;
+    justify-content: center;
+    gap: 15px;
+}
+
+.flashcard-btn {
+    background: linear-gradient(135deg, #3498db, #2980b9);
+    color: #fff;
+    border: none;
+    border-radius: 8px;
+    padding: 10px 20px;
+    cursor: pointer;
+    transition: background 0.3s ease;
+}
+
+.flashcard-btn:hover {
+    background: linear-gradient(135deg, #2980b9, #1c6ea4);
+}
+
 @media (max-width: 768px) {
     .menu-buttons {
         flex-direction: column;

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -25,6 +25,10 @@ class PronunciationQuest {
         
         // Додаємо прапорець, що блокує збереження прогресу після скидання
         this.blockProgressSaving = false;
+
+        // Індекс для режиму карток
+        this.flashcardIndex = 0;
+        this.flashcardsInitialized = false;
         
         this.words = {
             beginner: [
@@ -59,6 +63,11 @@ class PronunciationQuest {
                 { word: 'leisure', transcription: '/ˈleʒə/', stress: 1, audio: null, category: 'activities' },
                 { word: 'measure', transcription: '/ˈmeʒə/', stress: 1, audio: null, category: 'actions' },
                 { word: 'picture', transcription: '/ˈpɪktʃə/', stress: 1, audio: null, category: 'objects' }
+                ,{ word: 'apple', transcription: '/ˈæpl/', stress: 1, audio: null, category: 'food' }
+                ,{ word: 'doctor', transcription: '/ˈdɒktə/', stress: 1, audio: null, category: 'health' }
+                ,{ word: 'family', transcription: '/ˈfæmɪli/', stress: 1, audio: null, category: 'people' }
+                ,{ word: 'holiday', transcription: '/ˈhɒlədeɪ/', stress: 1, audio: null, category: 'events' }
+                ,{ word: 'music', transcription: '/ˈmjuːzɪk/', stress: 1, audio: null, category: 'culture' }
             ],
             intermediate: [
                 { word: 'advertisement', transcription: '/ədˈvɜːtɪsmənt/', stress: 2, audio: null, category: 'business' },
@@ -94,6 +103,11 @@ class PronunciationQuest {
                 { word: 'questionnaire', transcription: '/ˌkwestʃəˈneə/', stress: 3, audio: null, category: 'research' },
                 { word: 'restaurant', transcription: '/ˈrestrɒnt/', stress: 1, audio: null, category: 'places' },
                 { word: 'throughout', transcription: '/θruːˈaʊt/', stress: 2, audio: null, category: 'prepositions' }
+                ,{ word: 'analysis', transcription: '/əˈnæləsɪs/', stress: 2, audio: null, category: 'science' }
+                ,{ word: 'capacity', transcription: '/kəˈpæsəti/', stress: 2, audio: null, category: 'general' }
+                ,{ word: 'diversity', transcription: '/daɪˈvɜːsəti/', stress: 2, audio: null, category: 'society' }
+                ,{ word: 'efficient', transcription: '/ɪˈfɪʃnt/', stress: 2, audio: null, category: 'adjectives' }
+                ,{ word: 'heritage', transcription: '/ˈherɪtɪdʒ/', stress: 1, audio: null, category: 'culture' }
             ],
             advanced: [
                 { word: 'worcestershire', transcription: '/ˈwʊstəʃə/', stress: 1, audio: null, audioPath: 'assets/audio/words/advanced/worcestershire.mp3', category: 'places' },
@@ -135,6 +149,11 @@ class PronunciationQuest {
                 { word: 'xylophone', transcription: '/ˈzaɪləfəʊn/', stress: 1, audio: null, audioPath: 'assets/audio/words/advanced/xylophone.mp3', category: 'music' },
                 { word: 'yoghurt', transcription: '/ˈjɒɡət/', stress: 1, audio: null, audioPath: 'assets/audio/words/advanced/yoghurt.mp3', category: 'food' },
                 { word: 'zeitgeist', transcription: '/ˈzaɪtɡaɪst/', stress: 1, audio: null, audioPath: 'assets/audio/words/advanced/zeitgeist.mp3', category: 'culture' }
+                ,{ word: 'miscellaneous', transcription: '/ˌmɪsəˈleɪniəs/', stress: 3, audio: null, category: 'general' }
+                ,{ word: 'philanthropy', transcription: '/fɪˈlænθrəpi/', stress: 2, audio: null, category: 'society' }
+                ,{ word: 'quintessential', transcription: '/ˌkwɪntɪˈsenʃl/', stress: 3, audio: null, category: 'description' }
+                ,{ word: 'ubiquitous', transcription: '/juːˈbɪkwɪtəs/', stress: 2, audio: null, category: 'adjectives' }
+                ,{ word: 'whistleblower', transcription: '/ˈwɪslˌbləʊə/', stress: 1, audio: null, category: 'politics' }
             ]
         };
 
@@ -344,6 +363,12 @@ class PronunciationQuest {
                 }
             });
         }
+
+        // Події для режиму карток
+        document.getElementById('back-from-flashcards-btn')?.addEventListener('click', () => this.showMainMenu());
+        document.getElementById('flashcard-play-btn')?.addEventListener('click', () => this.playAudio());
+        document.getElementById('flashcard-reveal-btn')?.addEventListener('click', () => this.revealFlashcardInfo());
+        document.getElementById('flashcard-next-btn')?.addEventListener('click', () => this.nextFlashcard());
     }
 
     changeLevel(level) {
@@ -486,54 +511,55 @@ class PronunciationQuest {
     }
 
     playAudio() {
-        // Спершу намагаємося відтворити аудіо з API, якщо є
         const audio = document.getElementById('word-audio');
-        
+
+        // Якщо доступне реальне аудіо, спершу намагаємося відтворити його
         if (this.currentWord.audio) {
             console.log("Спроба відтворення аудіо:", this.currentWord.audio);
-            
-            // Використовуємо реальний аудіофайл
+
             audio.src = this.currentWord.audio;
             audio.playbackRate = this.playbackSpeed;
-            
-            // Додаємо обробники подій для відстеження стану
+
+            // Якщо аудіо почало відтворюватися, зупиняємо синтезований голос
+            const handlePlaying = () => {
+                clearTimeout(audioTimeout);
+                if (this.synthesis.speaking) {
+                    this.synthesis.cancel();
+                }
+            };
+
+            audio.onplaying = handlePlaying;
             audio.onplay = () => {
                 console.log("Аудіо почало відтворюватися");
             };
-            
             audio.onended = () => {
                 console.log("Відтворення аудіо завершено");
             };
-            
             audio.onerror = (error) => {
                 console.error('Помилка відтворення аудіо:', error);
-                // Перевіряємо, чи шлях є локальним
                 if (this.currentWord.audio === this.currentWord.audioPath) {
                     console.log("Помилка з локальним аудіо, спробуємо Web Speech API");
-                    this.currentWord.audio = null; // Скидаємо аудіо, щоб не намагатися знову його використати
+                    this.currentWord.audio = null;
                 }
+                clearTimeout(audioTimeout);
                 this.fallbackToSynthesizedAudio();
             };
-            
-            // Встановлюємо таймаут на випадок, якщо аудіо не відтворюється
+
+            // Якщо аудіо не почало відтворюватися протягом 3 секунд, використовуємо синтезований голос
             const audioTimeout = setTimeout(() => {
                 if (audio.paused) {
                     console.warn("Аудіо не почало відтворюватися протягом 3 секунд");
                     this.fallbackToSynthesizedAudio();
                 }
             }, 3000);
-            
-            // Очищаємо таймаут, якщо аудіо почало відтворюватися
-            audio.onplaying = () => {
-                clearTimeout(audioTimeout);
-            };
-            
+
             audio.play().catch(error => {
                 console.error('Помилка відтворення аудіо:', error);
+                clearTimeout(audioTimeout);
                 this.fallbackToSynthesizedAudio();
             });
         } else {
-            // Використовуємо синтезований голос як запасний варіант
+            // В іншому випадку одразу використовуємо синтезований голос
             this.fallbackToSynthesizedAudio();
         }
     }
@@ -1204,6 +1230,7 @@ class PronunciationQuest {
         const gameArea = document.querySelector('.game-area');
         const phoneticsZoneElement = document.getElementById('phonetics-zone');
         const tongueTwistersSection = document.getElementById('tongue-twisters-section');
+        const flashcardsSection = document.getElementById('flashcards-section');
         
         // Видаляємо активний стан з усіх кнопок режимів
         document.querySelectorAll('.mode-btn').forEach(btn => {
@@ -1222,6 +1249,9 @@ class PronunciationQuest {
         phoneticsZoneElement.style.display = 'none';
         if (tongueTwistersSection) {
             tongueTwistersSection.style.display = 'none';
+        }
+        if (flashcardsSection) {
+            flashcardsSection.style.display = 'none';
         }
         
         if (mode === 'quiz') {
@@ -1261,6 +1291,16 @@ class PronunciationQuest {
                 if (!this.tongueTwistersInitialized) {
                     this.initTongueTwisters();
                     this.tongueTwistersInitialized = true;
+                }
+            }
+        } else if (mode === 'flashcards') {
+            if (flashcardsSection) {
+                flashcardsSection.style.display = 'block';
+                if (!this.flashcardsInitialized) {
+                    this.initFlashcards();
+                    this.flashcardsInitialized = true;
+                } else {
+                    this.displayFlashcard();
                 }
             }
         } else if (mode === 'main-menu') {
@@ -1800,10 +1840,43 @@ class PronunciationQuest {
             console.log("Команда на повільне відтворення надіслана");
         } catch (error) {
             console.error("Помилка повільного відтворення через Web Speech API:", error);
-            
+
             // При помилці переходимо до візуального режиму
             this.showTongueTwisterVisually(currentTwister.text, true); // true для повільного режиму
         }
+    }
+
+    // --- Flashcards mode ---
+    initFlashcards() {
+        this.flashcardIndex = 0;
+        this.displayFlashcard();
+    }
+
+    displayFlashcard() {
+        const words = this.words[this.currentLevel];
+        if (this.flashcardIndex >= words.length) {
+            this.flashcardIndex = 0;
+        }
+
+        const wordItem = words[this.flashcardIndex];
+        this.currentWord = wordItem;
+
+        document.getElementById('flashcard-word').textContent = wordItem.word;
+        document.getElementById('flashcard-transcription').textContent = wordItem.transcription;
+        document.getElementById('flashcard-stress').textContent = `${wordItem.stress}-й склад`;
+        document.getElementById('flashcard-info').style.display = 'none';
+
+        this.loadAudioForCurrentWord();
+        this.synthesizeAudio();
+    }
+
+    revealFlashcardInfo() {
+        document.getElementById('flashcard-info').style.display = 'block';
+    }
+
+    nextFlashcard() {
+        this.flashcardIndex++;
+        this.displayFlashcard();
     }
 
     // Новий метод для показу головного меню
@@ -1812,6 +1885,7 @@ class PronunciationQuest {
         document.querySelector('.game-area').style.display = 'none';
         document.getElementById('phonetics-zone').style.display = 'none';
         document.getElementById('tongue-twisters-section').style.display = 'none';
+        document.getElementById('flashcards-section').style.display = 'none';
         
         // Показуємо головне меню
         const mainMenu = document.getElementById('main-menu');

--- a/index.html
+++ b/index.html
@@ -53,6 +53,11 @@
                     <div class="menu-btn-text">Скоромовки</div>
                     <div class="menu-btn-desc">Тренуйте вимову зі скоромовками</div>
                 </button>
+                <button class="menu-btn flashcard-btn" data-mode="flashcards">
+                    <div class="menu-icon">🃏</div>
+                    <div class="menu-btn-text">Картки</div>
+                    <div class="menu-btn-desc">Запам'ятовуйте нові слова</div>
+                </button>
             </div>
         </div>
 
@@ -163,6 +168,26 @@
             </div>
         </div>
 
+        <!-- Секція карток для запам'ятовування слів -->
+        <div id="flashcards-section" class="flashcards-section" style="display: none;">
+            <div class="back-navigation">
+                <button id="back-from-flashcards-btn" class="back-btn">← Повернутися до меню</button>
+            </div>
+            <h2 class="section-title">🃏 Картки</h2>
+            <div class="flashcard-container">
+                <div class="flashcard-word" id="flashcard-word">word</div>
+                <div class="flashcard-info" id="flashcard-info" style="display: none;">
+                    <div id="flashcard-transcription"></div>
+                    <div id="flashcard-stress"></div>
+                </div>
+                <div class="flashcard-controls">
+                    <button class="flashcard-btn" id="flashcard-play-btn">🔊</button>
+                    <button class="flashcard-btn" id="flashcard-reveal-btn">Показати</button>
+                    <button class="flashcard-btn" id="flashcard-next-btn">➡️</button>
+                </div>
+            </div>
+        </div>
+
         <div id="info-panel" class="info-panel">
             <h3>Як користуватися Pronunciation Quest</h3>
             <p>Ця гра допоможе вам покращити вимову англійських слів, зосереджуючись на особливостях британської вимови.</p>
@@ -170,6 +195,7 @@
                 <li><strong>Квіз:</strong> Перевіряйте свої знання транскрипції, наголосу та звуків</li>
                 <li><strong>Вивчення:</strong> Вивчайте фонетичні символи та їхню вимову</li>
                 <li><strong>Скоромовки:</strong> Тренуйте вимову зі складними фразами</li>
+                <li><strong>Картки:</strong> Запам'ятовуйте нові слова за допомогою карток</li>
             </ul>
             <p>Натисніть кнопку "Послухати", щоб почути правильну вимову. Вибирайте швидкість відтворення для зручності.</p>
         </div>


### PR DESCRIPTION
## Summary
- add new flashcards mode with simple controls
- hide/show new section from JS
- expand beginner, intermediate and advanced word lists
- update info panel and styles for new mode
- fix double audio playback by cancelling speech when real audio plays

## Testing
- `node -c assets/js/app.js`


------
https://chatgpt.com/codex/tasks/task_e_6842b424131483249ee506e28954282b